### PR TITLE
fix(Core): Missing updates for creatures

### DIFF
--- a/src/server/game/Grids/Notifiers/GridNotifiers.cpp
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.cpp
@@ -333,20 +333,7 @@ void ObjectUpdater::Visit(GridRefManager<T> &m)
     {
         obj = iter->GetSource();
         ++iter;
-        if (obj->IsInWorld())
-            obj->Update(i_timeDiff);
-    }
-}
-
-template<class T>
-void LargeObjectUpdater::Visit(GridRefManager<T> &m)
-{
-    T* obj;
-    for (typename GridRefManager<T>::iterator iter = m.begin(); iter != m.end(); )
-    {
-        obj = iter->GetSource();
-        ++iter;
-        if (obj->IsInWorld() && obj->IsVisibilityOverridden())
+        if (obj->IsInWorld() && (i_largeOnly == obj->IsVisibilityOverridden()))
             obj->Update(i_timeDiff);
     }
 }
@@ -384,4 +371,3 @@ bool AnyDeadUnitSpellTargetInRangeCheck::operator()(Creature* u)
 template void ObjectUpdater::Visit<Creature>(CreatureMapType&);
 template void ObjectUpdater::Visit<GameObject>(GameObjectMapType&);
 template void ObjectUpdater::Visit<DynamicObject>(DynamicObjectMapType&);
-template void LargeObjectUpdater::Visit<Creature>(CreatureMapType&);

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -141,19 +141,10 @@ namespace Trinity
     struct ObjectUpdater
     {
         uint32 i_timeDiff;
-        explicit ObjectUpdater(const uint32 diff) : i_timeDiff(diff) {}
+        bool i_largeOnly;
+        explicit ObjectUpdater(const uint32 diff, bool largeOnly) : i_timeDiff(diff), i_largeOnly(largeOnly) {}
         template<class T> void Visit(GridRefManager<T> &m);
         void Visit(PlayerMapType &) {}
-        void Visit(CorpseMapType &) {}
-    };
-
-    struct LargeObjectUpdater
-    {
-        uint32 i_timeDiff;
-        explicit LargeObjectUpdater(const uint32 diff) : i_timeDiff(diff) {}
-        template<class T> void Visit(GridRefManager<T> &m);
-        void Visit(GameObjectMapType &) {}
-        void Visit(DynamicObjectMapType &) {}
         void Visit(CorpseMapType &) {}
     };
 
@@ -1255,6 +1246,23 @@ namespace Trinity
             float _range;
             bool _reqAlive;
             bool _disallowGM;
+    };
+
+    class AnyPlayerExactPositionInGameObjectRangeCheck
+    {
+        public:
+            AnyPlayerExactPositionInGameObjectRangeCheck(GameObject const* go, float range) : _go(go), _range(range) {}
+            bool operator()(Player* u)
+            {
+                if (!_go->IsInRange(u->GetPositionX(), u->GetPositionY(), u->GetPositionZ(), _range))
+                    return false;
+
+                return true;
+            }
+
+        private:
+            GameObject const* _go;
+            float _range;
     };
 
     class NearestPlayerInObjectRangeCheck

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -1248,23 +1248,6 @@ namespace Trinity
             bool _disallowGM;
     };
 
-    class AnyPlayerExactPositionInGameObjectRangeCheck
-    {
-        public:
-            AnyPlayerExactPositionInGameObjectRangeCheck(GameObject const* go, float range) : _go(go), _range(range) {}
-            bool operator()(Player* u)
-            {
-                if (!_go->IsInRange(u->GetPositionX(), u->GetPositionY(), u->GetPositionZ(), _range))
-                    return false;
-
-                return true;
-            }
-
-        private:
-            GameObject const* _go;
-            float _range;
-    };
-
     class NearestPlayerInObjectRangeCheck
     {
         public:

--- a/src/server/game/Maps/Map.cpp
+++ b/src/server/game/Maps/Map.cpp
@@ -629,16 +629,16 @@ bool Map::IsGridLoaded(const GridCoord &p) const
 
 void Map::VisitNearbyCellsOfPlayer(Player* player, TypeContainerVisitor<Trinity::ObjectUpdater, GridTypeMapContainer> &gridVisitor,
     TypeContainerVisitor<Trinity::ObjectUpdater, WorldTypeMapContainer> &worldVisitor,
-    TypeContainerVisitor<Trinity::LargeObjectUpdater, GridTypeMapContainer> &largeObjectVisitor)
+    TypeContainerVisitor<Trinity::ObjectUpdater, GridTypeMapContainer> &largeObjectVisitor)
 {
     // check for valid position
     if (!player->IsPositionValid())
         return;
 
     // check normal grid activation range of the player
-    VisitNearbyCellsOf(player, gridVisitor, worldVisitor);
+    VisitNearbyCellsOf(player, gridVisitor, worldVisitor, largeObjectVisitor);
 
-    // check maximum visibility distance for large creatures (cells already visited by the normal check won't be visited again)
+    // check maximum visibility distance for large creatures
     CellArea area = Cell::CalculateCellArea(player->GetPositionX(), player->GetPositionY(), MAX_VISIBILITY_DISTANCE);
 
     for (uint32 x = area.low_bound.x_coord; x <= area.high_bound.x_coord; ++x)
@@ -648,10 +648,10 @@ void Map::VisitNearbyCellsOfPlayer(Player* player, TypeContainerVisitor<Trinity:
             // marked cells are those that have been visited
             // don't visit the same cell twice
             uint32 cell_id = (y * TOTAL_NUMBER_OF_CELLS_PER_MAP) + x;
-            if (isCellMarked(cell_id))
+            if (isCellMarkedLarge(cell_id))
                 continue;
 
-            markCell(cell_id);
+            markCellLarge(cell_id);
             CellCoord pair(x, y);
             Cell cell(pair);
 
@@ -661,7 +661,8 @@ void Map::VisitNearbyCellsOfPlayer(Player* player, TypeContainerVisitor<Trinity:
 }
 
 void Map::VisitNearbyCellsOf(WorldObject* obj, TypeContainerVisitor<Trinity::ObjectUpdater, GridTypeMapContainer> &gridVisitor,
-    TypeContainerVisitor<Trinity::ObjectUpdater, WorldTypeMapContainer> &worldVisitor)
+    TypeContainerVisitor<Trinity::ObjectUpdater, WorldTypeMapContainer> &worldVisitor,
+    TypeContainerVisitor<Trinity::ObjectUpdater, GridTypeMapContainer> &largeObjectVisitor)
 { 
     // Check for valid position
     if (!obj->IsPositionValid())
@@ -690,6 +691,12 @@ void Map::VisitNearbyCellsOf(WorldObject* obj, TypeContainerVisitor<Trinity::Obj
 
             Visit(cell, gridVisitor);
             Visit(cell, worldVisitor);
+
+            if (!isCellMarkedLarge(cell_id))
+            {
+                markCellLarge(cell_id);
+                Visit(cell, largeObjectVisitor);
+            }
         }
     }
 }
@@ -733,16 +740,17 @@ void Map::Update(const uint32 t_diff, const uint32 s_diff, bool  /*thread*/)
 
     /// update active cells around players and active objects
     resetMarkedCells();
+    resetMarkedCellsLarge();
 
-    Trinity::ObjectUpdater updater(t_diff);
+    Trinity::ObjectUpdater updater(t_diff, false);
     // for creature
     TypeContainerVisitor<Trinity::ObjectUpdater, GridTypeMapContainer  > grid_object_update(updater);
     // for pets
     TypeContainerVisitor<Trinity::ObjectUpdater, WorldTypeMapContainer > world_object_update(updater);
 
     // for large creatures
-    Trinity::LargeObjectUpdater largeObjectUpdater(t_diff);
-    TypeContainerVisitor<Trinity::LargeObjectUpdater, GridTypeMapContainer  > grid_large_object_update(largeObjectUpdater);
+    Trinity::ObjectUpdater largeObjectUpdater(t_diff, true);
+    TypeContainerVisitor<Trinity::ObjectUpdater, GridTypeMapContainer  > grid_large_object_update(largeObjectUpdater);
 
     // pussywizard: container for far creatures in combat with players
     std::vector<Creature*> updateList; updateList.reserve(10);
@@ -756,7 +764,7 @@ void Map::Update(const uint32 t_diff, const uint32 s_diff, bool  /*thread*/)
         if (!obj || !obj->IsInWorld())
             continue;
 
-        VisitNearbyCellsOf(obj, grid_object_update, world_object_update);
+        VisitNearbyCellsOf(obj, grid_object_update, world_object_update, grid_large_object_update);
     }
 
     // the player iterator is stored in the map object
@@ -788,7 +796,7 @@ void Map::Update(const uint32 t_diff, const uint32 s_diff, bool  /*thread*/)
                 ref = ref->next();
             }
             for (std::vector<Creature*>::const_iterator itr = updateList.begin(); itr != updateList.end(); ++itr)
-                VisitNearbyCellsOf(*itr, grid_object_update, world_object_update);
+                VisitNearbyCellsOf(*itr, grid_object_update, world_object_update, grid_large_object_update);
         }
     }
 

--- a/src/server/game/Maps/Map.h
+++ b/src/server/game/Maps/Map.h
@@ -297,10 +297,11 @@ class Map : public GridRefManager<NGridType>
         template<class T> void RemoveFromMap(T *, bool);
 
         void VisitNearbyCellsOf(WorldObject* obj, TypeContainerVisitor<Trinity::ObjectUpdater, GridTypeMapContainer> &gridVisitor,
-            TypeContainerVisitor<Trinity::ObjectUpdater, WorldTypeMapContainer> &worldVisitor);
+            TypeContainerVisitor<Trinity::ObjectUpdater, WorldTypeMapContainer> &worldVisitor,
+            TypeContainerVisitor<Trinity::ObjectUpdater, GridTypeMapContainer> &largeObjectVisitor);
         void VisitNearbyCellsOfPlayer(Player* player, TypeContainerVisitor<Trinity::ObjectUpdater, GridTypeMapContainer> &gridVisitor,
             TypeContainerVisitor<Trinity::ObjectUpdater, WorldTypeMapContainer> &worldVisitor,
-            TypeContainerVisitor<Trinity::LargeObjectUpdater, GridTypeMapContainer> &largeObjectVisitor);
+            TypeContainerVisitor<Trinity::ObjectUpdater, GridTypeMapContainer> &largeObjectVisitor);
         virtual void Update(const uint32, const uint32, bool thread = true);
 
         float GetVisibilityRange() const { return m_VisibleDistance; }
@@ -410,6 +411,9 @@ class Map : public GridRefManager<NGridType>
         void resetMarkedCells() { marked_cells.reset(); }
         bool isCellMarked(uint32 pCellId) { return marked_cells.test(pCellId); }
         void markCell(uint32 pCellId) { marked_cells.set(pCellId); }
+        void resetMarkedCellsLarge() { marked_cells_large.reset(); }
+        bool isCellMarkedLarge(uint32 pCellId) { return marked_cells_large.test(pCellId); }
+        void markCellLarge(uint32 pCellId) { marked_cells_large.set(pCellId); }
 
         bool HavePlayers() const { return !m_mapRefManager.isEmpty(); }
         uint32 GetPlayersCountExceptGMs() const;
@@ -609,6 +613,7 @@ class Map : public GridRefManager<NGridType>
         NGridType* i_grids[MAX_NUMBER_OF_GRIDS][MAX_NUMBER_OF_GRIDS];
         GridMap* GridMaps[MAX_NUMBER_OF_GRIDS][MAX_NUMBER_OF_GRIDS];
         std::bitset<TOTAL_NUMBER_OF_CELLS_PER_MAP*TOTAL_NUMBER_OF_CELLS_PER_MAP> marked_cells;
+        std::bitset<TOTAL_NUMBER_OF_CELLS_PER_MAP*TOTAL_NUMBER_OF_CELLS_PER_MAP> marked_cells_large;
 
         bool i_scriptLock;
         std::unordered_set<WorldObject*> i_objectsToRemove;


### PR DESCRIPTION
> ##### CHANGES PROPOSED:
> This PR fixes a problem introduced with PR #2304. Sadly I had a logic error in there: Cells visited only for large creatures were also marked as visited for all creatures, which is wrong because it prevents updates for those creatures. With this PR cells are marked as visited for large and normal creatures separately which ensures that each creature is updated.
> 
> Sadly I did not see this error in the first place as it only shows while playing with multiple players.
> 
> ##### ISSUES ADDRESSED:
> * Closes #2390
> * Closes #2399
> 
> ##### TESTS PERFORMED:
> * Tested build on Ubuntu 16.04 x64 / cmake 3.15.5 / clang 7.1.0 / MySQL 5.7
> * Tested successfully in-game
> 
> ##### HOW TO TEST THE CHANGES:
> Without this PR:
> 
> * Create 2 hunters on separate accounts, put their pets in "defensive" mode
> * `.go 7343.97 -896.434 915.94 571`
> * Attack one of the rhinos there with the pet of the first hunter
> * Attack the same rhino with the pet of the second hunter
> * Run away with the second hunter, constantly attacking the rhino with the pet, so it keeps following
> * One of the pets will stop getting updates, which means it "hangs" or "lags", unresponsive to the player's commands
> 
> With this PR the pets should just behave normally.
> 
> ##### KNOWN ISSUES AND TODO LIST:
> none
> 
> ##### Target branch(es):
> * [x]  Master
> 
> ## How to test AzerothCore PRs
> When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.
> 
> You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:
> 
> http://www.azerothcore.org/wiki/How-to-test-a-PR

