### PR TITLE
fix(Core/GameObjectScript): Environmental damage of burning game objects

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1573682333945401103.sql
+++ b/data/sql/updates/pending_db_world/rev_1573682333945401103.sql
@@ -1,0 +1,5 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1573682333945401103');
+
+DELETE FROM `gameobject` WHERE `id` IN (2061,2066);
+UPDATE `gameobject_template` SET `Data2` = 0, `ScriptName` = 'go_flames' WHERE `type` = 8 AND `Data2` = 2061;
+UPDATE `gameobject_template` SET `Data2` = 0, `ScriptName` = 'go_heat' WHERE `type` = 8 AND `Data2` = 2066;

--- a/src/server/game/Grids/Notifiers/GridNotifiers.h
+++ b/src/server/game/Grids/Notifiers/GridNotifiers.h
@@ -1256,6 +1256,23 @@ namespace Trinity
             bool _disallowGM;
     };
 
+    class AnyPlayerExactPositionInGameObjectRangeCheck
+    {
+        public:
+            AnyPlayerExactPositionInGameObjectRangeCheck(GameObject const* go, float range) : _go(go), _range(range) {}
+            bool operator()(Player* u)
+            {
+                if (!_go->IsInRange(u->GetPositionX(), u->GetPositionY(), u->GetPositionZ(), _range))
+                    return false;
+
+                return true;
+            }
+
+        private:
+            GameObject const* _go;
+            float _range;
+    };
+
     class NearestPlayerInObjectRangeCheck
     {
         public:

--- a/src/server/scripts/World/go_scripts.cpp
+++ b/src/server/scripts/World/go_scripts.cpp
@@ -37,6 +37,8 @@ EndContentData */
 #include "Spell.h"
 #include "Player.h"
 #include "WorldSession.h"
+#include "GridNotifiersImpl.h"
+#include "CellImpl.h"
 
 // Ours
 /*######
@@ -312,6 +314,99 @@ public:
     }
 };
 
+enum Flames
+{
+    SPELL_FLAMES = 7897
+};
+
+class go_flames : public GameObjectScript
+{
+public:
+    go_flames() : GameObjectScript("go_flames") { }
+
+    struct go_flamesAI : public GameObjectAI
+    {
+        go_flamesAI(GameObject* gameObject) : GameObjectAI(gameObject),
+            timer { 0 }
+        { }
+
+        void UpdateAI(uint32  diff)
+        {
+            timer += diff;
+            if (timer > 3000)
+            {
+                timer = 0;
+                std::list<Player*> players;
+                Trinity::AnyPlayerExactPositionInGameObjectRangeCheck checker(go, 0.3f);
+                Trinity::PlayerListSearcher<Trinity::AnyPlayerExactPositionInGameObjectRangeCheck> searcher(go, players, checker);
+                go->VisitNearbyWorldObject(0.3f, searcher);
+
+                if (players.size() > 0)
+                {
+                    std::list<Player*>::iterator itr = players.begin();
+                    std::advance(itr, urand(0, players.size() - 1));
+                    if (Creature* trigger = go->SummonTrigger((*itr)->GetPositionX(), (*itr)->GetPositionY(), (*itr)->GetPositionZ(), 0, 2000, true))
+                        trigger->CastSpell(trigger, SPELL_FLAMES);
+                }
+            }
+        }
+
+    private:
+        uint32 timer;
+    };
+
+    GameObjectAI* GetAI(GameObject* go) const
+    {
+        return new go_flamesAI(go);
+    }
+};
+
+enum Heat
+{
+    SPELL_HEAT = 7902
+};
+
+class go_heat : public GameObjectScript
+{
+public:
+    go_heat() : GameObjectScript("go_heat") { }
+
+    struct go_heatAI : public GameObjectAI
+    {
+        go_heatAI(GameObject* gameObject) : GameObjectAI(gameObject),
+            timer { 0 }
+        { }
+
+        void UpdateAI(uint32  diff)
+        {
+            timer += diff;
+            if (timer > 3000)
+            {
+                timer = 0;
+                std::list<Player*> players;
+                Trinity::AnyPlayerExactPositionInGameObjectRangeCheck checker(go, 0.3f);
+                Trinity::PlayerListSearcher<Trinity::AnyPlayerExactPositionInGameObjectRangeCheck> searcher(go, players, checker);
+                go->VisitNearbyWorldObject(0.3f, searcher);
+
+                if (players.size() > 0)
+                {
+                    std::list<Player*>::iterator itr = players.begin();
+                    std::advance(itr, urand(0, players.size() - 1));
+                    if (Creature* trigger = go->SummonTrigger((*itr)->GetPositionX(), (*itr)->GetPositionY(), (*itr)->GetPositionZ(), 0, 2000, true))
+                        trigger->CastSpell(trigger, SPELL_HEAT);
+                }
+            }
+        }
+
+    private:
+        uint32 timer;
+    };
+
+    GameObjectAI* GetAI(GameObject* go) const
+    {
+        return new go_heatAI(go);
+    }
+};
 
 
 // Theirs
@@ -1178,6 +1273,8 @@ void AddSC_go_scripts()
     new go_ethereum_stasis();
     new go_resonite_cask();
     new go_tadpole_cage();
+    new go_flames();
+    new go_heat();
 
     // Theirs
     new go_cat_figurine();


### PR DESCRIPTION
> ##### CHANGES PROPOSED:
> * Add 2 new game object scripts which handle the environmental damage spells only when the player is very near the boundary of the game object. This fixes small game objects, like braziers, burning the player from far away and big game objects, like bonfires, now finally can cause damage if standing near them. If more than one player is affected by the game object the environmental damage is placed on a random player to prevent multiple fire damage (this could easily kill low level players otherwise).
> * Remove all the trap game objects which were used to deal fire damage (template IDs 2061 and 2066) as they are not needed anymore (this frees up 2858 entries which can be used in the future for other game objects).
> * Change all game object templates of type "GAMEOBJECT_TYPE_SPELL_FOCUS" which used either ID 2061 or 2066 as traps to use the new game object scripts.
> 
> ##### ISSUES ADDRESSED:
> * Closes #2396
> * Closes #2397
> 
> ##### TESTS PERFORMED:
> * tested build on Ubuntu 16.04 / clang 7
> * tested successfully in-game
> 
> ##### HOW TO TEST THE CHANGES:
> Just run near burning objects, like bonfires, braziers, campfires, fireplaces etc. Examples:
> 
> * `.tele ValleyOfWisdom`: On your way to Thrall the Mighty Blazes should not burn the player from far away.
> * `.go o 23`: The bonfire should now cause fire damage
> 
> ##### KNOWN ISSUES AND TODO LIST:
> none
> 
> ##### Target branch(es):
> * [x]  Master
> 
> ## How to test AzerothCore PRs
> When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.
> 
> You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:
> 
> http://www.azerothcore.org/wiki/How-to-test-a-PR

