### PR TITLE
fix(Core/SpellScript): Remove hard-coded texts from the "Pit of Saron" c++ script

### DIFF
--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/pit_of_saron.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/pit_of_saron.cpp
@@ -1408,16 +1408,15 @@ public:
                         {
                             p->RewardPlayerAndGroupAtEvent(36764, caster); // alliance
                             p->RewardPlayerAndGroupAtEvent(36770, caster); // horde
+                            
+                            target->SetUInt32Value(UNIT_NPC_EMOTESTATE, 0);
+                            if (Creature* c = target->ToCreature())
+                            {
+                                c->DespawnOrUnsummon(7000);
+                                c->AI()->Talk(0, p);
+                                c->m_Events.AddEvent(new SlaveRunEvent(*c), c->m_Events.CalculateTime(3000));
+                            }
                         }
-                    target->SetUInt32Value(UNIT_NPC_EMOTESTATE, 0);
-                    Unit* caster = GetCaster();
-                    Player * p = caster->ToPlayer();
-                    if (Creature* c = target->ToCreature())
-                    {
-                        c->DespawnOrUnsummon(7000);
-                        c->AI()->Talk(0, p);
-                        c->m_Events.AddEvent(new SlaveRunEvent(*c), c->m_Events.CalculateTime(3000));
-                    }
                 }
         }
 

--- a/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/pit_of_saron.cpp
+++ b/src/server/scripts/Northrend/FrozenHalls/PitOfSaron/pit_of_saron.cpp
@@ -1354,32 +1354,6 @@ public:
     }
 };
 
-const char* slaveTexts[23] = {
-"I owe you a long night of drinking, my friend.",
-"Don't let a single one of them live.",
-"I can barely feel my arms, but I'll stand with you once I find some weapons.",
-"I can hardly believe my eyes. Thank you. Really, thank you.",
-"I owe you my life.",
-"I thought I might die in this pit. Thank you!",
-"I will find a way to repay you someday, hero.",
-"I'd almost given up hope.",
-"I'd lost all track of time in this forsaken place. You're a sight for sore eyes, friend.",
-"I'll fight by your side. Offer them no mercy.",
-"I'll join you as soon as I catch my breath, heroes. Thank you.",
-"I'm going to return to help free the rest of the slaves. Thank you again, hero.",
-"I'm going to return to the front of the quarry. Kill a few extra for me.",
-"I'm so glad you're here. I wouldn't have made it much longer.",
-"I'm with you, hero.",
-"If by life or death I can repay you, I will.",
-"Now is the time for revenge.",
-"Please, carry out our vengeance on the Scourgelord.",
-"Too many of us died in this pit. Far too many.",
-"When you kill the Pit Master, spit on his corpse for me, will you?",
-"You're a beautiful sight... you have no idea.",
-"Have my babies.",
-"I could just kiss you!"
-};
-
 const Position slaveFreePos[4] = {
     {699.82f, -82.68f, 512.6f, 0.0f},
     {643.51f, 79.20f, 511.57f, 0.0f},
@@ -1436,11 +1410,12 @@ public:
                             p->RewardPlayerAndGroupAtEvent(36770, caster); // horde
                         }
                     target->SetUInt32Value(UNIT_NPC_EMOTESTATE, 0);
+                    Unit* caster = GetCaster();
+                    Player * p = caster->ToPlayer();
                     if (Creature* c = target->ToCreature())
                     {
                         c->DespawnOrUnsummon(7000);
-                        uint32 maxIndex = (c->getGender() == GENDER_FEMALE ? 22 : 20);
-                        c->MonsterSay(slaveTexts[urand(0, maxIndex)], LANG_UNIVERSAL, 0);
+                        c->AI()->Talk(0, p);
                         c->m_Events.AddEvent(new SlaveRunEvent(*c), c->m_Events.CalculateTime(3000));
                     }
                 }


### PR DESCRIPTION
> ##### CHANGES PROPOSED:
> * Delete the spell script texts, so that they can be read from the database.
> 
> ##### ISSUES ADDRESSED:
> * Closes
> 
> ##### TESTS PERFORMED:
> * Windows 10
> * I only tried the Spanish texts.
>   [![](https://camo.githubusercontent.com/282026bf27b5c2634e294b6cacc193d9113fa381/687474703a2f2f7468756d62732e73756265666f746f732e636f6d2f36323865313139396130313735656438646637653531363238373066323132386f2e6a7067)](https://subefotos.com/ver/?628e1199a0175ed8df7e5162870f2128o.jpg)
> 
> ##### HOW TO TEST THE CHANGES:
> * Enter pit of saron
> * Releasing prisoners
> * Check that the dialogues are said in their respective language.
> 
> ##### KNOWN ISSUES AND TODO LIST:
> ##### Target branch(es):
> * [x]  Master
> 
> ## How to test AzerothCore PRs
> When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.
> 
> You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:
> 
> http://www.azerothcore.org/wiki/How-to-test-a-PR

