### PR TITLE
fix(DB/SAI): Enraged Feral Scar

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1574031504415896764.sql
+++ b/data/sql/updates/pending_db_world/rev_1574031504415896764.sql
@@ -1,0 +1,7 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1574031504415896764');
+
+DELETE FROM `smart_scripts` WHERE `source_type` = 0 AND `entryorguid` = 5295;
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(5295,0,0,0,2,0,100,1,0,30,0,0,0,11,8599,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Enraged Feral Scar - Between 0-30% Health - Cast Enrage (No Repeat)'),
+(5295,0,1,0,2,0,100,1,0,30,0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,'Enraged Feral Scar - Between 0-30% Health - Say Line 0 (No Repeat)');


### PR DESCRIPTION
> ##### CHANGES PROPOSED:
> The "Enraged Feral Scar" should just cast "Enrage", not "Frost Nova" or "Frostbolt Volley" (the latter caused the creature to just stand at a distance doing nothing because it has no mana to cast). I took over the changes from TC.
> 
> ##### ISSUES ADDRESSED:
> none
> 
> ##### TESTS PERFORMED:
> Tested successfully in-game
> 
> ##### HOW TO TEST THE CHANGES:
> * `.go cr id 5295`
> * The "Enraged Feral Scar" should now engage into melee combat and enrage when brought down to 30% health.
> 
> ##### KNOWN ISSUES AND TODO LIST:
> none
> 
> ##### Target branch(es):
> * [x]  Master
> 
> ## How to test AzerothCore PRs
> When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.
> 
> You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:
> 
> http://www.azerothcore.org/wiki/How-to-test-a-PR

