### PR TITLE
fix(DB/SAI): Re-added Snowblind Follower interaction for quest 14090

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1574778273250296900.sql
+++ b/data/sql/updates/pending_db_world/rev_1574778273250296900.sql
@@ -1,13 +1,6 @@
-DELETE FROM `smart_scripts` WHERE (`entryorguid`=29618 AND `source_type`=0);
+DELETE FROM `smart_scripts` WHERE `entryorguid` = 29618 AND `source_type` = 0 AND `id` IN (7,8,9);
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
 VALUES
-(29618, 0, 0, 1, 11, 0, 100, 0, 0, 0, 0, 0, 0, 20, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - On Respawn - Enable Auto Attack"),
-(29618, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - Linked - Enable Combat Movement"),
-(29618, 0, 2, 3, 1, 0, 100, 0, 1000, 60000, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - OOC - Disable Auto Attack"),
-(29618, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - Linked - Disable Combat Movement"),
-(29618, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 88, 2961800, 2961809, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - Linked - Call Random Action List"),
-(29618, 0, 5, 0, 58, 0, 100, 0, 0, 0, 0, 0, 0, 41, 1000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - On Waypoint Path Ended - Despawn After 1 Second"),
-(29618, 0, 6, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 41, 5000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - On Death - Despawn After 5 Seconds"),
-(29618, 0, 7, 8, 8, 0, 100, 0, 66474, 0, 4500, 4500, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - On Spellhit 'Throw Net' - Say Line 0"),
-(29618, 0, 8, 9, 61, 0, 100, 0, 0, 0, 0, 0, 0, 33, 34899, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - On Spellhit 'Throw Net' - Quest Credit 'Gormok Wants His Snobolds'"),
-(29618, 0, 9, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 41, 5000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - On Spellhit 'Throw Net' - Despawn in 5000 ms");
+(29618, 0, 7, 8, 8, 0, 100, 1, 66474, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Snowblind Follower - On Spellhit ''Throw Net'' - Say Line 0 (No Repeat)'),
+(29618, 0, 8, 9, 61, 0, 100, 0, 0, 0, 0, 0, 0, 33, 34899, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 'Snowblind Follower - Linked - Quest Credit ''Gormok Wants His Snobolds'''),
+(29618, 0, 9, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 41, 5000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 'Snowblind Follower - Linked - Despawn in 5000 ms');

--- a/data/sql/updates/pending_db_world/rev_1574778273250296900.sql
+++ b/data/sql/updates/pending_db_world/rev_1574778273250296900.sql
@@ -1,0 +1,13 @@
+DELETE FROM `smart_scripts` WHERE (`entryorguid`=29618 AND `source_type`=0);
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`)
+VALUES
+(29618, 0, 0, 1, 11, 0, 100, 0, 0, 0, 0, 0, 0, 20, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - On Respawn - Enable Auto Attack"),
+(29618, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 21, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - Linked - Enable Combat Movement"),
+(29618, 0, 2, 3, 1, 0, 100, 0, 1000, 60000, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - OOC - Disable Auto Attack"),
+(29618, 0, 3, 4, 61, 0, 100, 0, 0, 0, 0, 0, 0, 21, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - Linked - Disable Combat Movement"),
+(29618, 0, 4, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 88, 2961800, 2961809, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - Linked - Call Random Action List"),
+(29618, 0, 5, 0, 58, 0, 100, 0, 0, 0, 0, 0, 0, 41, 1000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - On Waypoint Path Ended - Despawn After 1 Second"),
+(29618, 0, 6, 0, 6, 0, 100, 0, 0, 0, 0, 0, 0, 41, 5000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - On Death - Despawn After 5 Seconds"),
+(29618, 0, 7, 8, 8, 0, 100, 0, 66474, 0, 4500, 4500, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - On Spellhit 'Throw Net' - Say Line 0"),
+(29618, 0, 8, 9, 61, 0, 100, 0, 0, 0, 0, 0, 0, 33, 34899, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - On Spellhit 'Throw Net' - Quest Credit 'Gormok Wants His Snobolds'"),
+(29618, 0, 9, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 41, 5000, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Snowblind Follower - On Spellhit 'Throw Net' - Despawn in 5000 ms");


### PR DESCRIPTION
> Adds to : #2354
> References taken from https://wowgaming.altervista.org/aowow/?quest=14090 / https://wowgaming.altervista.org/aowow/?quest=14141
> 
> ##### CHANGES PROPOSED:
> * Stoabrogga's PR #2354 added waypoints and event interaction to npc's in Garm's Rise but broke the functionality of quests 14090 and 14141
> * This commit fixes that by re-adding the missing SAI lines
> 
> ##### ISSUES ADDRESSED:
> ##### TESTS PERFORMED:
> * Tested in-game, using the given quest item on a Snowblind Follower rewards credit to the quests as intended.
> 
> ##### HOW TO TEST THE CHANGES:
> 1. .go c id 29618
> 2. .q add 14090
> 3. and/or .q add 14141
> 4. Use Weighted Net (item 46885) on a Snowblind Follower
> 5. Verify if the quest objective updates or not.
> 
> ##### Target branch(es):
> * [x]  Master
> 
> ## How to test AzerothCore PRs
> When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.
> 
> You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:
> 
> http://www.azerothcore.org/wiki/How-to-test-a-PR

