### PR TITLE
fix(DB/SAI): Fix SAI error during quest "The Seer's Relic"

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1574892827070035498.sql
+++ b/data/sql/updates/pending_db_world/rev_1574892827070035498.sql
@@ -1,0 +1,3 @@
+INSERT INTO `version_db_world` (`sql_rev`) VALUES ('1574892827070035498');
+
+UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 17405;


### PR DESCRIPTION
> ##### CHANGES PROPOSED:
> The NPC "Krun Spinebreaker" (ID 17405) has to be enabled for SAI or else the following error occurs during the quest "The Seer's Relic":
> `SmartScript: Action target Creature(entry: 17405) is not using SmartAI, action skipped to prevent crash.`
> 
> ##### ISSUES ADDRESSED:
> none
> 
> ##### TESTS PERFORMED:
> tested successfully in-game
> 
> ##### HOW TO TEST THE CHANGES:
> * preparation:
> 
> ```
> .q rem 9545
> .q a 9545
> .go 194.415 4143.8 73.7128 530
> ```
> 
> * proceed with the quest; the error mentioned above should not occur anymore
> 
> ##### KNOWN ISSUES AND TODO LIST:
> none
> 
> ##### Target branch(es):
> * [x]  Master
> 
> ## How to test AzerothCore PRs
> When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.
> 
> You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:
> 
> http://www.azerothcore.org/wiki/How-to-test-a-PR

